### PR TITLE
Jules azspice stack

### DIFF
--- a/rose-stem/include/meto/runtime-azspice-fcm-make-gnu.cylc
+++ b/rose-stem/include/meto/runtime-azspice-fcm-make-gnu.cylc
@@ -9,11 +9,7 @@
         inherit = METO_AZSPICE_GNU_BUILD
         pre-script = """
                      module purge
-                     module load csc/2025.11.19
-                     module load gcc/12.2.0
-                     module load mpich/4.2.3
-                     module load eccodes/2.34.0
-                     module load netcdf-fortran/4.6.1
+                     module load um/vn14.0
                      module list 2>&1
                      """
 
@@ -21,11 +17,7 @@
         inherit = METO_AZSPICE_GNU_BUILD
         pre-script = """
                      module purge
-                     module load csc/2025.11.19
-                     module load gcc/12.2.0
-                     module load mpich/4.2.3
-                     module load eccodes/2.34.0
-                     module load netcdf-fortran/4.6.1
+                     module load um/vn14.0
                      module list 2>&1
                      """
 

--- a/rose-stem/include/meto/runtime-azspice-fcm-make-gnu.cylc
+++ b/rose-stem/include/meto/runtime-azspice-fcm-make-gnu.cylc
@@ -9,9 +9,11 @@
         inherit = METO_AZSPICE_GNU_BUILD
         pre-script = """
                      module purge
-                     module load gcc/12.2.0-gcc-12.2.0-elnqzkg
-                     module load mpich/4.2.3-gcc-12.2.0-vqupwpn
-                     module load netcdf-fortran/4.6.1-gcc-12.2.0-3bu2pvj
+                     module load csc/2025.11.19
+                     module load gcc/12.2.0
+                     module load mpich/4.2.3
+                     module load eccodes/2.34.0
+                     module load netcdf-fortran/4.6.1
                      module list 2>&1
                      """
 
@@ -19,9 +21,11 @@
         inherit = METO_AZSPICE_GNU_BUILD
         pre-script = """
                      module purge
-                     module load gcc/12.2.0-gcc-12.2.0-elnqzkg
-                     module load mpich/4.2.3-gcc-12.2.0-vqupwpn
-                     module load netcdf-fortran/4.6.1-gcc-12.2.0-3bu2pvj
+                     module load csc/2025.11.19
+                     module load gcc/12.2.0
+                     module load mpich/4.2.3
+                     module load eccodes/2.34.0
+                     module load netcdf-fortran/4.6.1
                      module list 2>&1
                      """
 

--- a/rose-stem/include/meto/runtime-azspice-fcm-make.cylc
+++ b/rose-stem/include/meto/runtime-azspice-fcm-make.cylc
@@ -54,7 +54,7 @@
         execution time limit = PT5M
         pre-script = """
                      module purge
-                     module load nccmp/1.9.1.0-gcc-12.2.0-3jixlr4
+                     module load um/vn14.0
                      module list 2>&1
                      """
         [[[environment]]]


### PR DESCRIPTION
As in MetOffice/um#8 update the stack on azspice to avoid using old modules.
Andy has provided a wrapper module for UM era repos to provide some environment variables that are required.

# Test Suite Results - jules - jules_azspice_stack/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | jules_azspice_stack/run1 |
| Suite User | james.bruten |
| Workflow Start | 2025-11-27T17:28:11 |
| Groups Run | azspice |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| jules | [james-bruten-mo/jules@jules_azspice_stack](https://github.com/james-bruten-mo/jules/tree/jules_azspice_stack) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@main](https://github.com/MetOffice/SimSys_Scripts/tree/main) | True |

## Task Information
<details>
<summary>:white_check_mark: succeeded tasks - 230</summary>

| Task | State |
| :--- | :--- |
| extract_source | succeeded |
| fcm_make_meto_azspice_gnu_debug_noomp_nompi | succeeded |
| fcm_make_meto_azspice_gnu_omp_mpi | succeeded |
| fcm_make_meto_azspice_gnu_rivers-only_omp_mpi | succeeded |
| housekeep_meto_azspice_gnu_eraint_rfm_2ddata | succeeded |
| housekeep_meto_azspice_gnu_eraint_trip_2ddata | succeeded |
| housekeep_meto_azspice_gnu_gswp2_closures | succeeded |
| housekeep_meto_azspice_gnu_gswp2_es_1p1 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_es_beta | succeeded |
| housekeep_meto_azspice_gnu_gswp2_es_curr | succeeded |
| housekeep_meto_azspice_gnu_gswp2_euro4 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_gl4 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_gl7 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_irrig_limit_high_river_storage | succeeded |
| housekeep_meto_azspice_gnu_gswp2_irrig_limit_low_river_storage | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_restart | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_lrun | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun1 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun2 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_rivers-only | succeeded |
| housekeep_meto_azspice_gnu_gswp2_rivers_spinup | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_restart | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_restart_init_storage | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_restart_rivers-only_lrun | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun1 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun2 | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_rivers-only | succeeded |
| housekeep_meto_azspice_gnu_gswp2_trip_spinup | succeeded |
| housekeep_meto_azspice_gnu_gswp2_ukv | succeeded |
| housekeep_meto_azspice_gnu_gswp2_ukv_flake | succeeded |
| housekeep_meto_azspice_gnu_imogen_layeredc | succeeded |
| housekeep_meto_azspice_gnu_imogen_layeredc_ch4 | succeeded |
| housekeep_meto_azspice_gnu_imogen_layeredc_co2conc | succeeded |
| housekeep_meto_azspice_gnu_imogen_layeredc_dtempg | succeeded |
| housekeep_meto_azspice_gnu_imogen_layeredc_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_crops | succeeded |
| housekeep_meto_azspice_gnu_loobos_daily_disagg | succeeded |
| housekeep_meto_azspice_gnu_loobos_euro4 | succeeded |
| housekeep_meto_azspice_gnu_loobos_fire | succeeded |
| housekeep_meto_azspice_gnu_loobos_fire_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_forecast | succeeded |
| housekeep_meto_azspice_gnu_loobos_gl4 | succeeded |
| housekeep_meto_azspice_gnu_loobos_gl4_cable | succeeded |
| housekeep_meto_azspice_gnu_loobos_gl7 | succeeded |
| housekeep_meto_azspice_gnu_loobos_gl8 | succeeded |
| housekeep_meto_azspice_gnu_loobos_gl8_medlyn | succeeded |
| housekeep_meto_azspice_gnu_loobos_irrig | succeeded |
| housekeep_meto_azspice_gnu_loobos_irrig_nirrtile | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_c1p1 | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_c1p1_fire | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_cn | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_cn_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0 | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_biocrop | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_biocrop_agexpand | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_biocrop_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_deposition | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd1 | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2 | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2h2 | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_deposition_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_es_1p0_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_layeredcn | succeeded |
| housekeep_meto_azspice_gnu_loobos_jules_layeredcn_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_julesc | succeeded |
| housekeep_meto_azspice_gnu_loobos_julesc_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_prescribe_sthuf | succeeded |
| housekeep_meto_azspice_gnu_loobos_trif | succeeded |
| housekeep_meto_azspice_gnu_loobos_trif_spinup | succeeded |
| housekeep_meto_azspice_gnu_loobos_ukv | succeeded |
| housekeep_meto_azspice_gnu_loobos_ukv_deposition | succeeded |
| housekeep_meto_azspice_gnu_loobos_vegdrag | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm1_traitF | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm4_traitF | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm5_traitF | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm6_traitF | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm6_traitF_srfT | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm6_traitT | succeeded |
| housekeeping_meto_azspice_gnu_loobos_crm6_traitT_farquhar | succeeded |
| metadata_checker | succeeded |
| meto_azspice_gnu_eraint_rfm_2ddata | succeeded |
| meto_azspice_gnu_eraint_trip_2ddata | succeeded |
| meto_azspice_gnu_gswp2_closures | succeeded |
| meto_azspice_gnu_gswp2_es_1p1 | succeeded |
| meto_azspice_gnu_gswp2_es_beta | succeeded |
| meto_azspice_gnu_gswp2_es_curr | succeeded |
| meto_azspice_gnu_gswp2_euro4 | succeeded |
| meto_azspice_gnu_gswp2_gl4 | succeeded |
| meto_azspice_gnu_gswp2_gl7 | succeeded |
| meto_azspice_gnu_gswp2_irrig_limit_high_river_storage | succeeded |
| meto_azspice_gnu_gswp2_irrig_limit_low_river_storage | succeeded |
| meto_azspice_gnu_gswp2_rivers | succeeded |
| meto_azspice_gnu_gswp2_rivers_restart | succeeded |
| meto_azspice_gnu_gswp2_rivers_restart_rivers-only_lrun | succeeded |
| meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun1 | succeeded |
| meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun2 | succeeded |
| meto_azspice_gnu_gswp2_rivers_rivers-only | succeeded |
| meto_azspice_gnu_gswp2_rivers_spinup | succeeded |
| meto_azspice_gnu_gswp2_trip | succeeded |
| meto_azspice_gnu_gswp2_trip_restart | succeeded |
| meto_azspice_gnu_gswp2_trip_restart_init_storage | succeeded |
| meto_azspice_gnu_gswp2_trip_restart_rivers-only_lrun | succeeded |
| meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun1 | succeeded |
| meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun2 | succeeded |
| meto_azspice_gnu_gswp2_trip_rivers-only | succeeded |
| meto_azspice_gnu_gswp2_trip_spinup | succeeded |
| meto_azspice_gnu_gswp2_ukv | succeeded |
| meto_azspice_gnu_gswp2_ukv_flake | succeeded |
| meto_azspice_gnu_imogen_layeredc | succeeded |
| meto_azspice_gnu_imogen_layeredc_ch4 | succeeded |
| meto_azspice_gnu_imogen_layeredc_co2conc | succeeded |
| meto_azspice_gnu_imogen_layeredc_dtempg | succeeded |
| meto_azspice_gnu_imogen_layeredc_spinup | succeeded |
| meto_azspice_gnu_loobos_crm1_traitF | succeeded |
| meto_azspice_gnu_loobos_crm4_traitF | succeeded |
| meto_azspice_gnu_loobos_crm5_traitF | succeeded |
| meto_azspice_gnu_loobos_crm6_traitF | succeeded |
| meto_azspice_gnu_loobos_crm6_traitF_srfT | succeeded |
| meto_azspice_gnu_loobos_crm6_traitT | succeeded |
| meto_azspice_gnu_loobos_crm6_traitT_farquhar | succeeded |
| meto_azspice_gnu_loobos_crops | succeeded |
| meto_azspice_gnu_loobos_daily_disagg | succeeded |
| meto_azspice_gnu_loobos_euro4 | succeeded |
| meto_azspice_gnu_loobos_fire | succeeded |
| meto_azspice_gnu_loobos_fire_spinup | succeeded |
| meto_azspice_gnu_loobos_forecast | succeeded |
| meto_azspice_gnu_loobos_gl4 | succeeded |
| meto_azspice_gnu_loobos_gl4_cable | succeeded |
| meto_azspice_gnu_loobos_gl7 | succeeded |
| meto_azspice_gnu_loobos_gl8 | succeeded |
| meto_azspice_gnu_loobos_gl8_medlyn | succeeded |
| meto_azspice_gnu_loobos_irrig | succeeded |
| meto_azspice_gnu_loobos_irrig_nirrtile | succeeded |
| meto_azspice_gnu_loobos_jules_c1p1 | succeeded |
| meto_azspice_gnu_loobos_jules_c1p1_fire | succeeded |
| meto_azspice_gnu_loobos_jules_cn | succeeded |
| meto_azspice_gnu_loobos_jules_cn_spinup | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0 | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_biocrop | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_biocrop_agexpand | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_biocrop_spinup | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_deposition | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd1 | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2 | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2h2 | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_deposition_spinup | succeeded |
| meto_azspice_gnu_loobos_jules_es_1p0_spinup | succeeded |
| meto_azspice_gnu_loobos_jules_layeredcn | succeeded |
| meto_azspice_gnu_loobos_jules_layeredcn_spinup | succeeded |
| meto_azspice_gnu_loobos_julesc | succeeded |
| meto_azspice_gnu_loobos_julesc_spinup | succeeded |
| meto_azspice_gnu_loobos_prescribe_sthuf | succeeded |
| meto_azspice_gnu_loobos_trif | succeeded |
| meto_azspice_gnu_loobos_trif_spinup | succeeded |
| meto_azspice_gnu_loobos_ukv | succeeded |
| meto_azspice_gnu_loobos_ukv_deposition | succeeded |
| meto_azspice_gnu_loobos_vegdrag | succeeded |
| nccmp_meto_azspice_gnu_eraint_rfm_2ddata | succeeded |
| nccmp_meto_azspice_gnu_eraint_trip_2ddata | succeeded |
| nccmp_meto_azspice_gnu_gswp2_closures | succeeded |
| nccmp_meto_azspice_gnu_gswp2_es_1p1 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_es_beta | succeeded |
| nccmp_meto_azspice_gnu_gswp2_es_curr | succeeded |
| nccmp_meto_azspice_gnu_gswp2_euro4 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_gl4 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_gl7 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_irrig_limit_high_river_storage | succeeded |
| nccmp_meto_azspice_gnu_gswp2_irrig_limit_low_river_storage | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_restart | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_lrun | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_lrun_nrun2 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun1 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_restart_rivers-only_nrun2 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_rivers_rivers-only | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart_init_storage | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart_rivers-only_lrun | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart_rivers-only_lrun_nrun2 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun1 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_restart_rivers-only_nrun2 | succeeded |
| nccmp_meto_azspice_gnu_gswp2_trip_rivers-only | succeeded |
| nccmp_meto_azspice_gnu_gswp2_ukv | succeeded |
| nccmp_meto_azspice_gnu_gswp2_ukv_flake | succeeded |
| nccmp_meto_azspice_gnu_imogen_layeredc | succeeded |
| nccmp_meto_azspice_gnu_imogen_layeredc_ch4 | succeeded |
| nccmp_meto_azspice_gnu_imogen_layeredc_co2conc | succeeded |
| nccmp_meto_azspice_gnu_imogen_layeredc_dtempg | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm1_traitF | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm4_traitF | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm5_traitF | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm6_traitF | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm6_traitF_srfT | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm6_traitT | succeeded |
| nccmp_meto_azspice_gnu_loobos_crm6_traitT_farquhar | succeeded |
| nccmp_meto_azspice_gnu_loobos_crops | succeeded |
| nccmp_meto_azspice_gnu_loobos_daily_disagg | succeeded |
| nccmp_meto_azspice_gnu_loobos_euro4 | succeeded |
| nccmp_meto_azspice_gnu_loobos_fire | succeeded |
| nccmp_meto_azspice_gnu_loobos_forecast | succeeded |
| nccmp_meto_azspice_gnu_loobos_gl4 | succeeded |
| nccmp_meto_azspice_gnu_loobos_gl4_cable | succeeded |
| nccmp_meto_azspice_gnu_loobos_gl7 | succeeded |
| nccmp_meto_azspice_gnu_loobos_gl8 | succeeded |
| nccmp_meto_azspice_gnu_loobos_gl8_medlyn | succeeded |
| nccmp_meto_azspice_gnu_loobos_irrig | succeeded |
| nccmp_meto_azspice_gnu_loobos_irrig_nirrtile | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_c1p1 | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_c1p1_fire | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_cn | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0 | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_biocrop | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_biocrop_agexpand | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_deposition | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd1 | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2 | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_es_1p0_deposition_dd2h2 | succeeded |
| nccmp_meto_azspice_gnu_loobos_jules_layeredcn | succeeded |
| nccmp_meto_azspice_gnu_loobos_julesc | succeeded |
| nccmp_meto_azspice_gnu_loobos_prescribe_sthuf | succeeded |
| nccmp_meto_azspice_gnu_loobos_trif | succeeded |
| nccmp_meto_azspice_gnu_loobos_ukv | succeeded |
| nccmp_meto_azspice_gnu_loobos_ukv_deposition | succeeded |
| nccmp_meto_azspice_gnu_loobos_vegdrag | succeeded |
| remote_init_azspice | succeeded |
| site_validator | succeeded |
| umdp3_checker | succeeded |
</details>
