### PR TITLE
update trigger

### DIFF
--- a/.github/workflows/check-cr-approved.yaml
+++ b/.github/workflows/check-cr-approved.yaml
@@ -1,8 +1,6 @@
 name: Check CR approved
 
 on:
-    pull_request:
-        types: [opened, synchronize, reopened, edited]
     pull_request_review:
         types: [submitted, edited, dismissed]
     workflow_dispatch:


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled when known -->
Code Reviewer: @jennyhickson 

Thinking more closely, we don't need the pull_request trigger for the check-cr-approved action. Just running after a review is enough