### PR TITLE
Rose stem fixes for cehwl site

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 | GitHub user | Real Name | Affiliation | Date |
 | ----------- | --------- | ----------- | ---- |
 | james-bruten-mo | James Bruten | Met Office | 2025-12-09 |
+| ppharris | Phil Harris | UKCEH | 2025-12-18 |

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -19,8 +19,6 @@ $external_libs =
 $inc_paths =
 $lib_paths =
 
-$SOURCE_PATH_PREFIX = river
-
 # File that FCM should use to check MPI dependencies under JULES_MPI=nompi.
 $nompi_trigger_file = river/src/control/rivers-standalone/river.F90
 

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -44,7 +44,8 @@ extract.location[river] = $HERE/../..
 # be rewritten to allow more of JULES to be excluded.
 extract.path-excl[river] = / # everything
 
-extract.path-incl[river] = src/control/rivers-standalone \
+extract.path-incl[river] = $extract_path_incl \
+			   src/control/rivers-standalone \
 			   src/initialisation/rivers-standalone \
 			   src/io/rivers-standalone \
 			   src/science/river_routing \
@@ -219,8 +220,7 @@ extract.path-incl[river] = src/control/rivers-standalone \
 #-------------------------------------------------------------------------------
 # This could be removed by moving associated init_drive code to
 # init_disaggregator
-			   src/control/standalone/var/disaggregated_precip.F90 \
-			   $extract_path_incl
+			   src/control/standalone/var/disaggregated_precip.F90
 
 ################################################################################
 # Configure the preprocess step

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -21,8 +21,8 @@ $lib_paths =
 
 $SOURCE_PATH_PREFIX = river
 
-$mpi_trigger_file = $SOURCE_PATH_PREFIX/src/control/rivers-standalone/river.F90
-
+# File that FCM should use to check MPI dependencies under JULES_MPI=nompi.
+$nompi_trigger_file = river/src/control/rivers-standalone/river.F90
 
 # Select a platform config; provided by the user.
 $JULES_PLATFORM{?}        = custom

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -21,6 +21,9 @@ $lib_paths =
 
 $SOURCE_PATH_PREFIX = river
 
+$mpi_trigger_file = $SOURCE_PATH_PREFIX/src/control/rivers-standalone/river.F90
+
+
 # Select a platform config; provided by the user.
 $JULES_PLATFORM{?}        = custom
 
@@ -227,10 +230,6 @@ extract.path-incl[river] = src/control/rivers-standalone \
 preprocess.target{category} = src
 preprocess.target{task} = install process
 preprocess.prop{file-ext.h} = .inc
-
-# Explicit dependencies to ensure that FCM compiles/links code that doesn't have
-# an explicit interface.
-build.prop{dep.o}[river/src/control/rivers-standalone/river.F90] = mpi_init.o
 
 ################################################################################
 # Configure the build step

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -228,6 +228,9 @@ preprocess.target{category} = src
 preprocess.target{task} = install process
 preprocess.prop{file-ext.h} = .inc
 
+# Explicit dependencies to ensure that FCM compiles/links code that doesn't have
+# an explicit interface.
+build.prop{dep.o}[river/src/control/rivers-standalone/river.F90] = mpi_init.o
 
 ################################################################################
 # Configure the build step

--- a/etc/fcm-make/make-river.cfg
+++ b/etc/fcm-make/make-river.cfg
@@ -10,6 +10,7 @@
 # Use environment variables to control the configuration via include files
 ################################################################################
 # Variables defined initially so we can append to them later:
+$extract_path_incl = bin utils/drhook_dummy
 $fpp_defs{?} = RIVERS_ONLY
 $fflags =
 $ldflags =
@@ -17,6 +18,8 @@ $external_mods =
 $external_libs =
 $inc_paths =
 $lib_paths =
+
+$SOURCE_PATH_PREFIX = river
 
 # Select a platform config; provided by the user.
 $JULES_PLATFORM{?}        = custom
@@ -40,9 +43,7 @@ extract.location[river] = $HERE/../..
 # be rewritten to allow more of JULES to be excluded.
 extract.path-excl[river] = / # everything
 
-extract.path-incl[river] = bin \
-			   utils/drhook_dummy \
-			   src/control/rivers-standalone \
+extract.path-incl[river] = src/control/rivers-standalone \
 			   src/initialisation/rivers-standalone \
 			   src/io/rivers-standalone \
 			   src/science/river_routing \
@@ -217,7 +218,8 @@ extract.path-incl[river] = bin \
 #-------------------------------------------------------------------------------
 # This could be removed by moving associated init_drive code to
 # init_disaggregator
-			   src/control/standalone/var/disaggregated_precip.F90
+			   src/control/standalone/var/disaggregated_precip.F90 \
+			   $extract_path_incl
 
 ################################################################################
 # Configure the preprocess step

--- a/etc/fcm-make/make.cfg
+++ b/etc/fcm-make/make.cfg
@@ -18,6 +18,9 @@ $external_libs =
 $inc_paths =
 $lib_paths =
 
+$mpi_trigger_file = jules/src/control/standalone/jules.F90
+
+
 # Select a platform config; provided by the user.
 $JULES_PLATFORM{?}        = custom
 

--- a/etc/fcm-make/make.cfg
+++ b/etc/fcm-make/make.cfg
@@ -18,8 +18,8 @@ $external_libs =
 $inc_paths =
 $lib_paths =
 
-$mpi_trigger_file = jules/src/control/standalone/jules.F90
-
+# File that FCM should use to check MPI dependencies under JULES_MPI=nompi.
+$nompi_trigger_file = jules/src/control/standalone/jules.F90
 
 # Select a platform config; provided by the user.
 $JULES_PLATFORM{?}        = custom

--- a/etc/fcm-make/mpi/nompi.cfg
+++ b/etc/fcm-make/mpi/nompi.cfg
@@ -12,3 +12,7 @@ $external_libs = $external_libs $oasis_libs $ncdf_libs_dynamic
 
 # Add additional flags for dynamic linking for NetCDF
 $ldflags = $ldflags $ncdf_ldflags_dynamic
+
+# Explicit dependencies to ensure that FCM compiles/links code that doesn't have
+# an explicit interface.
+build.prop{dep.o}[$mpi_trigger_file] = mpi_init.o

--- a/etc/fcm-make/mpi/nompi.cfg
+++ b/etc/fcm-make/mpi/nompi.cfg
@@ -15,4 +15,4 @@ $ldflags = $ldflags $ncdf_ldflags_dynamic
 
 # Explicit dependencies to ensure that FCM compiles/links code that doesn't have
 # an explicit interface.
-build.prop{dep.o}[$mpi_trigger_file] = mpi_init.o
+build.prop{dep.o}[$nompi_trigger_file] = mpi_init.o

--- a/etc/fcm-make/platform/ceh-rocky9.cfg
+++ b/etc/fcm-make/platform/ceh-rocky9.cfg
@@ -1,0 +1,23 @@
+################################################################################
+# This platform file should be used when building on the JULES CEH Linux
+# CEHwl1
+#
+# It makes sure that the compiler is gfortran, that MPI is off (since the
+# default NetCDF installation does not support MPI), and that the NetCDF paths
+# are correctly set up should the user switch NetCDF on
+################################################################################
+
+# Load environment variable pre-settings
+include = $HERE/envars.cfg
+
+# Override any of the input variables that we need to for the CEH Linux
+# CEHwl1
+$JULES_REMOTE = local
+$JULES_COMPILER = gfortran_10_plus
+$JULES_NETCDF = netcdf
+$JULES_MPI = nompi
+$JULES_NETCDF_INC_PATH = /usr/lib64/gfortran/modules
+$JULES_NETCDF_LIB_PATH = /usr/lib64
+
+# Now load the the build config settings based on the supplied environment variables.
+include = $HERE/load_settings.cfg

--- a/rose-stem/include/cehwl1/runtime.cylc
+++ b/rose-stem/include/cehwl1/runtime.cylc
@@ -6,7 +6,7 @@
         inherit = None, EXTRACT_AND_BUILD, LINUX
         [[[environment]]]
             ROSE_TASK_N_JOBS = 2
-            JULES_PLATFORM = ceh
+            JULES_PLATFORM = ceh-rocky9
 
     [[fcm_make_debug]]
         inherit = CEH_BUILD
@@ -24,7 +24,7 @@
         inherit = None, EXTRACT_AND_BUILD_RIVER, LINUX
         [[[environment]]]
             ROSE_TASK_N_JOBS = 2
-            JULES_PLATFORM = ceh
+            JULES_PLATFORM = ceh-rocky9
             JULES_BUILD = normal
             JULES_OMP = omp
 
@@ -35,10 +35,10 @@
         inherit = None, LINUX, COMPUTE
         platform = localhost
         [[[environment]]]
-            LOOBOS_INSTALL_DIR = /data/rosestem/loobos/
-            GSWP2_INSTALL_DIR = /data/rosestem/gswp2
-            ERAINT_INSTALL_DIR = /data/rosestem/eraint/
-            IMOGEN_INSTALL_DIR = /data/rosestem/imogen/
+            LOOBOS_INSTALL_DIR = /mnt/rosestem/loobos/
+            GSWP2_INSTALL_DIR = /mnt/rosestem/gswp2
+            ERAINT_INSTALL_DIR = /mnt/rosestem/eraint/
+            IMOGEN_INSTALL_DIR = /mnt/rosestem/imogen/
 
     [[remote_init_ceh]]
         inherit = CEH_COMPUTE
@@ -406,7 +406,7 @@
     [[CEH_NETCDF_COMPARISON]]
         inherit = None, LINUX, NETCDF_COMPARISON
         [[[environment]]]
-            KGO_DIR = /data/rosestem/rose-stem-kgo/{{ KGO_VERSION }}
+            KGO_DIR = /mnt/rosestem/rose-stem-kgo/{{ KGO_VERSION }}
 
     [[nccmp_loobos_gl4]]
         inherit = KGO_CHECK, CEH_NETCDF_COMPARISON

--- a/rose-stem/include/cehwl1/runtime.cylc
+++ b/rose-stem/include/cehwl1/runtime.cylc
@@ -27,6 +27,7 @@
             JULES_PLATFORM = ceh-rocky9
             JULES_BUILD = normal
             JULES_OMP = omp
+            SOURCE_PATH_PREFIX = river
 
 ###############################################################################
 ## Compute jobs


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @james-bruten-mo 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

- fixes #24 

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] Comments have been included that aid undertanding and enhance the
      readability of the code
- [x] My changes generate no new warnings
- [x] **N/A** If editing `rose-meta/jules-shared` then have you supplied a linked UM PR?

## Testing

- [x] I have tested this change locally, using the JULES rose-stem suite
- [x] **N/A** If shared files have been modified, I have run the UM and LFRic Apps rose
      stem suites
- [x] **N/A** If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [x] **N/A** I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

I've run the Rose stem tests at `SITE=cehwl1`, which includes the newly running `rivers-only` tasks, and `SITE=meto`.  Both `trac.log` files are pasted below.

<!-- Paste your trac.log from testing output here -->

# Test Suite Results - jules - vn8.0_stem/run2 - SITE = cehwl1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [vn8.0_stem/run2](https://cylchub/services/cylc-review/cycles/ppha/?suite=vn8.0_stem%2Frun2) |
| Suite User | ppha |
| Workflow Start | 2026-01-21T13:22:40 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| jules | [ppharris/jules@cehwl_fix_rivers](https://github.com/ppharris/jules/tree/cehwl_fix_rivers) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2025.12.1](https://github.com/MetOffice/SimSys_Scripts/tree/2025.12.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 210

# Test Suite Results - jules - vn8.0_stem/run3 - SITE = meto

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [vn8.0_stem/run3](https://cylchub/services/cylc-review/cycles/philip.harris/?suite=vn8.0_stem%2Frun3) |
| Suite User | philip.harris |
| Workflow Start | 2026-01-21T14:36:43 |
| Groups Run | all |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| jules | [ppharris/jules@cehwl_fix_rivers](https://github.com/ppharris/jules/tree/cehwl_fix_rivers) | False |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2025.12.1](https://github.com/MetOffice/SimSys_Scripts/tree/2025.12.1) | True |

## Task Information
:white_check_mark: succeeded tasks - 667

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] **N/A** Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] **N/A** Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## Approvals

Please request all relevant approvals. See the CodeOwners.txt file for section
owners.

### Technical

- [ ] JULES Code Owner
- [ ] OpenMP
- [x] River Routing
- [ ] Rose Stem
- [ ] Rose Metadata
- [ ] Upgrade Macros

### Scientific

- [ ] Surface
- [ ] Hydrology
- [ ] Vegetation
- [ ] Veg3 RED Demography
- [ ] Biogechemistry
- [ ] Biogenic fluxes
- [ ] Fire
- [ ] Lakes
- [ ] Evaluation
- [ ] Imogen

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
