### PR TITLE
switch to 2nd last workflow run

### DIFF
--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -80,7 +80,6 @@ jobs:
         run: |
           # Get workflow id of last run to upload an artifact
           run_id=$(gh run list -R MetOffice/jules -b main -w user-guide.yaml --limit 2 --json databaseId | jq -r '.[1].databaseId')
-          echo "run_id: $run_id"
 
           # Download tarred artifact
           gh run download -R MetOffice/jules $run_id -n github-pages

--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -73,7 +73,7 @@ jobs:
         run: uv run make clean html
 
       - name: Download Artifact
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        # if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -90,7 +90,7 @@ jobs:
 
 
       - name: Build HTML docs for deployment
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        # if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -67,13 +67,19 @@ jobs:
         working-directory: ${{ env.JULES_PATH }}/doc
         run: uv run sphinx-lint source
 
+      - name: Build HTML docs for testing
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        working-directory: ${{ env.JULES_PATH }}/doc
+        run: uv run make clean html
+
       - name: Download Artifact
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get workflow id of last run to upload an artifact
-          run_id=$(gh run list -R MetOffice/jules -b main -w user-guide.yaml --limit 1 --json databaseId | jq -r '.[0].databaseId')
+          run_id=$(gh run list -R MetOffice/jules -b main -w user-guide.yaml --limit 2 --json databaseId | jq -r '.[1].databaseId')
 
           # Download tarred artifact
           gh run download -R MetOffice/jules $run_id -n github-pages
@@ -83,7 +89,8 @@ jobs:
           tar -xf artifact.tar -C ${{ env.ARTIFACT_PATH }}
 
 
-      - name: Build HTML docs
+      - name: Build HTML docs for deployment
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -101,19 +108,20 @@ jobs:
 
       # -- Deploy to GitHub Pages only on push to upstream main
       - name: Setup GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         uses: actions/configure-pages@v5
 
       - name: Upload artifact to GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
           path: ${{ env.OUTPUT_PATH }}
           # Use maximum retention days to avoid rebuilding all versions if possible
           retention-days: 90
+          overwrite: True
 
       - name: Deploy to GitHub Pages
         id: deployment
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
         uses: actions/deploy-pages@v4

--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -68,12 +68,12 @@ jobs:
         run: uv run sphinx-lint source
 
       - name: Build HTML docs for testing
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'pull_request'
         working-directory: ${{ env.JULES_PATH }}/doc
         run: uv run make clean html
 
       - name: Download Artifact
-        # if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -90,7 +90,7 @@ jobs:
 
 
       - name: Build HTML docs for deployment
-        # if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -108,20 +108,19 @@ jobs:
 
       # -- Deploy to GitHub Pages only on push to upstream main
       - name: Setup GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
         uses: actions/configure-pages@v5
 
       - name: Upload artifact to GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
           path: ${{ env.OUTPUT_PATH }}
           # Use maximum retention days to avoid rebuilding all versions if possible
           retention-days: 90
-          overwrite: True
 
       - name: Deploy to GitHub Pages
         id: deployment
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release') }}
+        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
         uses: actions/deploy-pages@v4

--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -30,6 +30,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      should-deploy: ${{ steps.check-deploy.outputs.should-deploy }}
     env:
       PYTHON_VRSN: '3.13'
       JULES_PATH: jules
@@ -38,6 +40,15 @@ jobs:
       VENV_PATH: jules/doc/.venv
 
     steps:
+      - name: Check deployment conditions
+        id: check-deploy
+        run: |
+          if [[ "${{ github.repository }}" == "MetOffice/jules" && "${{ github.ref_name }}" == "main" && ("${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "merge_group" || "${{ github.event_name }}" == "release" || "${{ github.event_name }}" == "workflow_dispatch") ]]; then
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-deploy=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -68,12 +79,12 @@ jobs:
         run: uv run sphinx-lint source
 
       - name: Build HTML docs for testing
-        if: github.event_name == 'pull_request'
+        if: steps.check-deploy.outputs.should-deploy == 'false'
         working-directory: ${{ env.JULES_PATH }}/doc
         run: uv run make clean html
 
       - name: Download Artifact
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+        if: steps.check-deploy.outputs.should-deploy == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -89,7 +100,7 @@ jobs:
 
 
       - name: Build HTML docs for deployment
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+        if: steps.check-deploy.outputs.should-deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -107,11 +118,11 @@ jobs:
 
       # -- Deploy to GitHub Pages only on push to upstream main
       - name: Setup GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+        if: steps.check-deploy.outputs.should-deploy == 'true'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact to GitHub Pages
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+        if: steps.check-deploy.outputs.should-deploy == 'true'
         uses: actions/upload-pages-artifact@v4
         with:
           name: github-pages
@@ -121,5 +132,5 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        if: ${{ github.repository == 'MetOffice/jules' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+        if: steps.check-deploy.outputs.should-deploy == 'true'
         uses: actions/deploy-pages@v4

--- a/.github/workflows/user-guide.yaml
+++ b/.github/workflows/user-guide.yaml
@@ -80,13 +80,13 @@ jobs:
         run: |
           # Get workflow id of last run to upload an artifact
           run_id=$(gh run list -R MetOffice/jules -b main -w user-guide.yaml --limit 2 --json databaseId | jq -r '.[1].databaseId')
+          echo "run_id: $run_id"
 
           # Download tarred artifact
           gh run download -R MetOffice/jules $run_id -n github-pages
 
           # Create output directory and untar
-          mkdir -p ${{ env.ARTIFACT_PATH }}
-          tar -xf artifact.tar -C ${{ env.ARTIFACT_PATH }}
+          tar -xf artifact.tar --one-top-level=artifact
 
 
       - name: Build HTML docs for deployment


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: 
Code Reviewer: @yaswant

<!-- To be completed by the developer -->

Use the 2nd to last run of the workflow on main to download the artifact from - the most recent would be the current run and won't have uploaded an artifact yet.

Instead of running for all versions on `pull_request`, only build the latest docs.

Update the triggers for the full build and deployment to include `workflow_dispatch` and `release`

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's style guidelines
- [ ] Comments have been included that aid undertanding and enhance the
      readability of the code
- [ ] My changes generate no new warnings
- [ ] If editing `rose-meta/jules-shared` then have you supplied a linked UM PR?

## Testing

- [ ] I have tested this change locally, using the JULES rose-stem suite
- [ ] If shared files have been modified, I have run the UM and LFRic Apps rose
      stem suites
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## Approvals

Please request all relevant approvals. See the CodeOwners.txt file for section
owners.

### Technical

- [ ] JULES Code Owner
- [ ] OpenMP
- [ ] River Routing
- [ ] Rose Stem
- [ ] Rose Metadata
- [ ] Upgrade Macros

### Scientific

- [ ] Surface
- [ ] Hydrology
- [ ] Vegetation
- [ ] Veg3 RED Demography
- [ ] Biogechemistry
- [ ] Biogenic fluxes
- [ ] Fire
- [ ] Lakes
- [ ] Evaluation
- [ ] Imogen

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
