### PR TITLE
Release notes for vn8.2/ Summer 2026

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 | GitHub user     | Real Name        | Affiliation | Date       |
 | --------------- | ---------------- | ----------- | ---------- |
 | yaswant         | Yaswant Pradhan  | Met Office  | 2026-06-30 |
+| doucla          | Douglas Clark    | UKCEH       | 2026-07-03 |

--- a/doc/source/release_notes/JULES8-0.rst
+++ b/doc/source/release_notes/JULES8-0.rst
@@ -26,7 +26,7 @@ General/Technical changes
 Bugs fixed
 ----------
 
- *  An upgrade macro that was missied from the previous release has been added. (#1619)
+ *  An upgrade macro that was missed from the previous release has been added. (#1619)
  *  Removed default diagnostic flags used for LFRic. (#1627)
 
 

--- a/doc/source/release_notes/JULES8-2.rst
+++ b/doc/source/release_notes/JULES8-2.rst
@@ -1,0 +1,46 @@
+JULES version 8.2 Release Notes
+===============================
+
+The JULES vn8.2 release consists of approximately 22 contributions, including work by many people. The `JULES repository <https://github.com/MetOffice/jules>`_ is now fully open to public access following adoption of the BSD 3-Clause licence.
+
+Full details of the changes committed for JULES vn8.2 can be found on the `JULES GitHub repository <https://github.com/MetOffice/jules/milestone/3>`_.
+
+Issue numbers are indicated below, e.g. #72.
+
+Science changes
+---------------
+
+ * The form of the relationship between soil decomposition and soil moisture is controlled by :nml:mem:`JULES_SOIL_BIOGEOCHEM::cs_decomp_soil_moist_func`, allowing for reduced decomposition in very wet soils. (#72)
+ * Heating from decomposition of soil is included via switch :nml:mem:`JULES_SOIL_BIOGEOCHEM::l_bgc_heat`. (#111)
+ * A new irrigation scheme, activated by the switch :nml:mem:`JULES_IRRIG::irrig_option`, applies new methods for irrigation on the surface tiles. The code now has two additional grass tiles (C3_irrig and C4_irrig) which are irrigated (see :nml:mem:`JULES_PFTPARM::irrig_pft_io`). On these tiles, the soil moisture availability factor is set to 1.0 and soil moisture extraction is disabled. This functionality can only be used with :nml:mem:`JULES_IRRIG::l_irrig_dmd` = FALSE. (#107)
+
+
+Bug fixes
+---------
+ *  Fixed a bug (which previously would result in a segmentation fault) related to metstats when running JULES standalone with :nml:mem:`FIRE_SWITCHES::l_fire` = TRUE and more than one and point. (#85)
+ *  Fixed issues in the daily weather disaggregator (see :nml:mem:`JULES_DRIVE::l_daily_disagg`) which previously would invert the diurnal cycle in high latitude regions under polar day/night. (#83)
+
+
+General/Technical changes
+-------------------------
+
+ *  Inland river flow (for endorheic basics) is passed through the OASIS coupler, for coupling to an ocean model. This is enabled via :nml:mem:`JULES_HYDROLOGY::l_inland` and only affects the rivers-only build of JULES (:nml:mem:`JULES_MODEL_ENVIRONMENT::lsm_id` = 3). (#89)
+ *  Metadata for :nml:lst:`JULES_PFTPARM` migrated to the shared metadata in jules-shared. (#42)
+ *  Added the jules-lfric metadata section (moved from lfric_apps). (#110)
+ *  Corrections to workflow. (#71, 94)
+ *  Added a CODEOWNERS file to the JULES repository to notify code owners when their areas of the JULES source code are updated, and later updates to that file (#87, 109, 112)
+
+
+Changes to testing
+------------------
+
+ *  Replaced the Rose Stem configuration for NIWA's previous HPC with a new ESNZ Cascade configuration. It also removes tests for which input files are not currently publicly available and introduces a compiler configuration for Intel OneAPI compilers. (#108)
+
+
+Documentation and licence updates
+---------------------------------
+
+ *  Updates associated with many of the above changes, release notes, and more. (#45, 80, 124)
+ *  Addition of the JULES Contributor Licence Agreement. (#50)
+
+Documentation can be viewed on the github page `<https://metoffice.github.io/jules/>`_.

--- a/doc/source/release_notes/JULES8-2.rst
+++ b/doc/source/release_notes/JULES8-2.rst
@@ -18,7 +18,7 @@ Science changes
 Bug fixes
 ---------
  *  Fixed a bug (which previously would result in a segmentation fault) related to metstats when running JULES standalone with :nml:mem:`FIRE_SWITCHES::l_fire` = TRUE and more than one and point. (#85)
- *  Fixed issues in the daily weather disaggregator (see :nml:mem:`JULES_DRIVE::l_daily_disagg`) which previously would invert the diurnal cycle in high latitude regions under polar day/night. (#83)
+ *  Fixed issues in the daily weather disaggregator (see :nml:mem:`JULES_DRIVE::l_daily_disagg`) which previously would invert the diurnal cycle in high latitude regions under polar day/night. This will change existing results. (#83)
 
 
 General/Technical changes

--- a/doc/source/release_notes/contents.rst
+++ b/doc/source/release_notes/contents.rst
@@ -3,6 +3,7 @@ Release notes
 =============
 
 .. toctree::
+   JULES8-2
    JULES8-1
    JULES8-0
    JULES7-9


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @james-bruten-mo 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->
Closes #124.
Release notes for vn8.2.
As this change only affects documentation (no code), most of the checklist below does not apply.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's style guidelines
- [ ] Comments have been included that aid undertanding and enhance the
      readability of the code
- [ ] My changes generate no new warnings
- [ ] If editing `rose-meta/jules-shared` then have you supplied a linked UM and LFRic Apps PR?

## Testing

- [ ] I have tested this change locally, using the JULES rose-stem suite
- [ ] If shared files have been modified, I have run the UM and LFRic Apps rose
      stem suites
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [x] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

## Approvals

Please request all relevant approvals. See the CodeOwners.txt file for section
owners.

### Technical

- [x] JULES Code Owner
- [ ] OpenMP
- [ ] River Routing
- [ ] Rose Stem
- [ ] Rose Metadata
- [ ] Upgrade Macros

### Scientific

- [ ] Surface
- [ ] Hydrology
- [ ] Vegetation
- [ ] Veg3 RED Demography
- [ ] Biogechemistry
- [ ] Biogenic fluxes
- [ ] Fire
- [ ] Lakes
- [ ] Evaluation
- [ ] Imogen

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

_Please alert the code reviewer via a tag when you have approved the SR_

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
